### PR TITLE
Improve parseRecursive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/ryankurte/go-structparse
+
+go 1.12
+
+require (
+	github.com/stretchr/testify v1.5.1
+	gopkg.in/yaml.v2 v2.3.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/parse.go
+++ b/parse.go
@@ -60,7 +60,7 @@ func parseRecursive(parsers Parsers, val reflect.Value) reflect.Value {
 		if o.IsValid() {
 			res := parseRecursive(parsers, o)
 			if res != reflect.ValueOf(nil) {
-				return res
+				return res.Addr()
 			}
 		}
 	case reflect.Interface:

--- a/parse.go
+++ b/parse.go
@@ -98,7 +98,7 @@ func parseRecursive(parsers Parsers, val reflect.Value) reflect.Value {
 		}
 		return val
 	case reflect.String:
-		if parsers.StringParser != nil {
+		if parsers.StringParser != nil && val.Type().AssignableTo(reflect.TypeOf("")) {
 			value := parsers.StringParser.ParseString(val.String())
 			return reflect.ValueOf(value)
 		}

--- a/parse_test.go
+++ b/parse_test.go
@@ -127,4 +127,22 @@ func TestParsing(t *testing.T) {
 
 		assert.EqualValues(t, "REPLACED", c.Bar.Name)
 	})
+
+	t.Run("struct with pointer field", func(t *testing.T) {
+		fem := FakeEnvMapper{"TEST", "REPLACED"}
+		type bar struct {
+			Name       string
+			unexported string
+		}
+		type foo struct {
+			Bar *bar
+		}
+
+		c := foo{Bar: &bar{Name: "TEST", unexported: "unexported"}}
+
+		Strings(&fem, &c)
+
+		assert.EqualValues(t, "REPLACED", c.Bar.Name)
+		assert.EqualValues(t, "unexported", c.Bar.unexported)
+	})
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -98,4 +98,33 @@ func TestParsing(t *testing.T) {
 
 		assert.EqualValues(t, "REPLACED", foo.Bar)
 	})
+
+	t.Run("map", func(t *testing.T) {
+		fem := FakeEnvMapper{"TEST", "REPLACED"}
+		type foo struct {
+			Name string
+		}
+		c := map[string]foo{"1": {"TEST"}, "2": {"TEST"}}
+
+		Strings(&fem, &c)
+
+		assert.EqualValues(t, "REPLACED", c["1"].Name)
+		assert.EqualValues(t, "REPLACED", c["2"].Name)
+	})
+
+	t.Run("struct", func(t *testing.T) {
+		fem := FakeEnvMapper{"TEST", "REPLACED"}
+		type bar struct {
+			Name string
+		}
+		type foo struct {
+			Bar bar
+		}
+
+		c := foo{Bar: bar{"TEST"}}
+
+		Strings(&fem, &c)
+
+		assert.EqualValues(t, "REPLACED", c.Bar.Name)
+	})
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -7,6 +7,7 @@ package structparse
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -78,10 +79,23 @@ func TestParsing(t *testing.T) {
 		assert.EqualValues(t, "boop", c.Fake["test2"]["test1"])
 	})
 
-    t.Run("Handles non-supported types", func(t *testing.T) {
+	t.Run("Handles non-supported types", func(t *testing.T) {
 		fem := FakeEnvMapper{"TEST", "REPLACED"}
-        c := struct {Fake bool} { false }
-        Strings(&fem, &c)
-    })
+		c := struct{ Fake bool }{false}
+		Strings(&fem, &c)
+	})
 
+	t.Run("struct with time", func(t *testing.T) {
+		fem := FakeEnvMapper{"TEST", "REPLACED"}
+		type Foo struct {
+			Bar  string
+			Time time.Time
+		}
+
+		foo := Foo{Bar: "TEST"}
+
+		Strings(&fem, &foo)
+
+		assert.EqualValues(t, "REPLACED", foo.Bar)
+	})
 }


### PR DESCRIPTION
Hello,
This PR fixes:
- struct in map
- pointer field
- unexported field
- type string can't be assigned to string
- add go.mod support